### PR TITLE
Add alternative paths of CUPTI and NVPerf for CMake

### DIFF
--- a/cpp/cmake/FindCUPTI.cmake
+++ b/cpp/cmake/FindCUPTI.cmake
@@ -46,6 +46,7 @@ find_path(CUPTI_INCLUDE_DIR cupti.h
   HINTS
   ${CUPTI_DIR}/include
   ${CUPTI_CUDA_HOME}/extras/CUPTI/include
+  ${CUPTI_CUDA_HOME}/include
   /usr/local/cuda/extras/CUPTI/include
 )
 
@@ -53,6 +54,7 @@ find_library(CUPTI_LIBRARY cupti
   HINTS
   ${CUPTI_DIR}/lib/x64
   ${CUPTI_CUDA_HOME}/extras/CUPTI/lib64
+  ${CUPTI_CUDA_HOME}/lib64
   /usr/local/cuda/extras/CUPTI/lib64
 )
 

--- a/cpp/cmake/FindNVPerf.cmake
+++ b/cpp/cmake/FindNVPerf.cmake
@@ -44,6 +44,7 @@ find_library(NVPerf_HOST_LIBRARY nvperf_host
   HINTS
   ${CUPTI_DIR}/lib/x64
   ${CUPTI_CUDA_HOME}/extras/CUPTI/lib64
+  ${CUPTI_CUDA_HOME}/lib64
   /usr/local/cuda/extras/CUPTI/lib64
 )
 
@@ -51,6 +52,7 @@ find_library(NVPerf_TARGET_LIBRARY nvperf_target
   HINTS
   ${CUPTI_DIR}/lib/x64
   ${CUPTI_CUDA_HOME}/extras/CUPTI/lib64
+  ${CUPTI_CUDA_HOME}/lib64
   /usr/local/cuda/extras/CUPTI/lib64
 )
 


### PR DESCRIPTION
If CUPTI is not installed via the run file (and installed using repository package), its libraries will be extracted to `/usr/local/cuda/lib64` instead of `/usr/local/cuda/extras/CUPTI/lib64`. We need to add these lines so that CMake would know where to find these libraries. 