### PR TITLE
Updated cmake version in docker and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Prerequsites:
 - A system equiped with an Nvidia GPU with properly configured CUDA
 - [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit-archive)
 - [cmake v3.17+](https://github.com/Kitware/CMake/releases)
+  - Note that Habitat does not build properly with cmake v3.24.0 and v3.24.1 due to a bug in cmake
 - [Git Large File Storage](https://git-lfs.github.com/) - which contains pre-trained habitat models
 
 ```zsh
@@ -86,10 +87,10 @@ where `11-x` represents the version of CUDA you have installed.
 
 Follow these steps to download and install a precompiled version of CMake:
 ```bash
-wget https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0-linux-x86_64.sh
-chmod +x cmake-3.24.0-linux-x86_64.sh
+wget https://github.com/Kitware/CMake/releases/download/v3.24.2/cmake-3.24.2-linux-x86_64.sh
+chmod +x cmake-3.24.2-linux-x86_64.sh
 mkdir /opt/cmake
-sh cmake-3.24.0-linux-x86_64.sh --prefix=/opt/cmake --skip-license
+sh cmake-3.24.2-linux-x86_64.sh --prefix=/opt/cmake --skip-license
 ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
 ```
 You can verify the version of CMake you installed with the following:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Prerequsites:
 - A system equiped with an Nvidia GPU with properly configured CUDA
 - [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit-archive)
 - [cmake v3.17+](https://github.com/Kitware/CMake/releases)
-  - Note that Habitat does not build properly with cmake v3.24.0 and v3.24.1 due to a bug in cmake
+  - Note that Habitat does not build properly with cmake v3.24.0 and v3.24.1 due to a bug in cmake. This bug is fixed by [this change](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7608/diffs) which has been merged in v3.24.2
 - [Git Large File Storage](https://git-lfs.github.com/) - which contains pre-trained habitat models
 
 ```zsh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,9 +26,9 @@ RUN pip3 install pillow>=7.2.0 pandas>=1.1.2 tqdm>=4.49.0
 #  make install
 
 #iInstall latest cmake
-ADD https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0-linux-x86_64.sh /cmake-3.24.0-linux-x86_64.sh
+ADD https://github.com/Kitware/CMake/releases/download/v3.24.2/cmake-3.24.2-linux-x86_64.sh /cmake-3.24.2-linux-x86_64.sh
 RUN mkdir /opt/cmake
-RUN sh /cmake-3.24.0-linux-x86_64.sh --prefix=/opt/cmake --skip-license
+RUN sh /cmake-3.24.2-linux-x86_64.sh --prefix=/opt/cmake --skip-license
 RUN ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
 RUN cmake --version
 


### PR DESCRIPTION
Updated cmake version so it does not uses a buggy version that cannot build Habitat. v3.24.0 and v3.24.1 are affected by this bug. It has been fixed [here](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7608/diffs) and merged in v3.24.2