### PR TITLE
Fix Git LFS Pointers

### DIFF
--- a/analyzer/habitat/data/.gitattributes
+++ b/analyzer/habitat/data/.gitattributes
@@ -1,1 +1,1 @@
-*.pth filter=lfs diff=lfs merge=lfs -text
+**/*.pth filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Looks like `analyzer/habitat/data/lstm/model.pth` was not properly committed to Git LFS. When I cloned the repo, I got a dirty state. This PR fixes.
After updating the Git LFS filters I had to run `git lfs migrate import --no-rewrite analyzer/habitat/data/lstm/model.pth`


Testing strategy:
1. Do a fresh clone of this repository
2. `git lfs pull`
