### PR TITLE
Add alternative CUPTI/NVPerf paths

### DIFF
--- a/cpp/cmake/FindCUPTI.cmake
+++ b/cpp/cmake/FindCUPTI.cmake
@@ -47,6 +47,7 @@ find_path(CUPTI_INCLUDE_DIR cupti.h
   ${CUPTI_DIR}/include
   ${CUPTI_CUDA_HOME}/extras/CUPTI/include
   ${CUPTI_CUDA_HOME}/include
+  /usr/local/cuda/include
   /usr/local/cuda/extras/CUPTI/include
 )
 
@@ -55,6 +56,7 @@ find_library(CUPTI_LIBRARY cupti
   ${CUPTI_DIR}/lib/x64
   ${CUPTI_CUDA_HOME}/extras/CUPTI/lib64
   ${CUPTI_CUDA_HOME}/lib64
+  /usr/local/cuda/lib64
   /usr/local/cuda/extras/CUPTI/lib64
 )
 

--- a/cpp/cmake/FindNVPerf.cmake
+++ b/cpp/cmake/FindNVPerf.cmake
@@ -45,6 +45,7 @@ find_library(NVPerf_HOST_LIBRARY nvperf_host
   ${CUPTI_DIR}/lib/x64
   ${CUPTI_CUDA_HOME}/extras/CUPTI/lib64
   ${CUPTI_CUDA_HOME}/lib64
+  /usr/local/cuda/lib64
   /usr/local/cuda/extras/CUPTI/lib64
 )
 
@@ -53,6 +54,7 @@ find_library(NVPerf_TARGET_LIBRARY nvperf_target
   ${CUPTI_DIR}/lib/x64
   ${CUPTI_CUDA_HOME}/extras/CUPTI/lib64
   ${CUPTI_CUDA_HOME}/lib64
+  /usr/local/cuda/lib64
   /usr/local/cuda/extras/CUPTI/lib64
 )
 


### PR DESCRIPTION
I thought we've fixed this already, but apparently not.
This PR tells cmake where to find cupti/nvperf.